### PR TITLE
Changed generateTotpUri optional parameters

### DIFF
--- a/types/authenticator/index.d.ts
+++ b/types/authenticator/index.d.ts
@@ -32,16 +32,17 @@ export function generateToken(formattedKey: string): string;
  * - SHA1 (default)
  * - SHA256
  * - SHA512
- * @param digits The digits parameter may have the values 6 or 8, and determines
- * how long of a one-time passcode to display to the user.
- * @param period The amount of time the TOTP code will be valid for, in seconds.
+ * @param digits (default 6) The digits parameter may have the values 6 or 8, 
+ * and determines how long of a one-time passcode to display to the user.
+ * @param period (default 30) The amount of time the TOTP code will be valid for,
+ * in seconds.
  */
 export function generateTotpUri(formattedKey: string,
-                                accountName: string,
-                                issuer: string,
-                                algorithm: string,
-                                digits: number,
-                                period: number): string;
+                                accountName?: string,
+                                issuer?: string,
+                                algorithm?: string,
+                                digits?: number,
+                                period?: number): string;
 
 /**
  * Validates a time-based token within a +/- 30 second (90 seconds) window


### PR DESCRIPTION
Now parameters have correct typings as it is in JS version of authenticator package
#55149

Please fill in this template.


Select one of these and delete the others:

If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: https://git.coolaj86.com/coolaj86/node-authenticator.js/src/branch/master/authenticator.js#L60
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
